### PR TITLE
Select board configuration at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,22 @@ INCLUDES = -I. \
 		   -I$(SRCDIR)/uboot-port/arch/arm/include \
 
 MCU = -mcpu=cortex-a7 -march=armv7ve -mfpu=neon-vfpv4 -mlittle-endian -mfloat-abi=hard
+
+
 ARCH_CFLAGS = -DUSE_FULL_LL_DRIVER \
 			  -DSTM32MP157Cxx \
 			  -DSTM32MP1 \
-			  -DCORE_CA7 \
-			  $(EXTRA_ARCH_CFLAGS) \
+			  -DCORE_CA7
+
+ifeq ($(BOARD_CONF),"OSD32")
+	ARCH_CFLAGS += -DBOARD_CONF_OSD32
+endif
+ifeq ($(BOARD_CONF),"DK2")
+	ARCH_CFLAGS += -DBOARD_CONF_DK2
+endif
+ifneq ($(BOARD_CONF_PATH),)
+	ARCH_CFLAGS += -DBOARD_CONF_PATH=$(BOARD_CONF_PATH)
+endif
 
 AFLAGS = $(MCU)
 
@@ -58,7 +69,7 @@ CFLAGS = -g2 \
 		 $(EXTRACFLAGS)\
 
 CXXFLAGS = $(CFLAGS) \
-		-std=c++2a \
+		-std=c++20 \
 		-fno-rtti \
 		-fno-exceptions \
 		-fno-unwind-tables \

--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,16 @@ ARCH_CFLAGS = -DUSE_FULL_LL_DRIVER \
 			  -DSTM32MP1 \
 			  -DCORE_CA7
 
-ifeq ($(BOARD_CONF),"OSD32")
+ifeq ("$(BOARD_CONF)","OSD32")
 	ARCH_CFLAGS += -DBOARD_CONF_OSD32
-endif
-ifeq ($(BOARD_CONF),"DK2")
+else
+ifeq ("$(BOARD_CONF)","DK2")
 	ARCH_CFLAGS += -DBOARD_CONF_DK2
+else
+ifneq ("$(BOARD_CONF)","")
+	ARCH_CFLAGS += -DBOARD_CONF_PATH=$(BOARD_CONF)
 endif
-ifneq ($(BOARD_CONF_PATH),)
-	ARCH_CFLAGS += -DBOARD_CONF_PATH=$(BOARD_CONF_PATH)
+endif
 endif
 
 AFLAGS = $(MCU)

--- a/src/board_conf.hh
+++ b/src/board_conf.hh
@@ -6,18 +6,20 @@
 // -DBOARD_CONF_PATH="path/file.hh" or #define BOARD_CONF_PATH "path/file.hh" to use a custom board conf file.
 // Passing a compile flag -DBOARD_CONF_XXX is the preferred method, but you may also place the #define before any #include "board_conf.hh"
 
-#ifdef BOARD_CONF_PATH
 #define HEADER_STRING_I(s) #s
 #define HEADER_STRING(s) HEADER_STRING_I(s)
+
+#if defined(BOARD_CONF_PATH)
 #include HEADER_STRING(BOARD_CONF_PATH)
 
 #elif defined(BOARD_CONF_OSD32)
-#include "osd32brk_conf.hh"
+#include "board_conf/osd32brk_conf.hh"
 
 #elif defined(BOARD_CONF_DK2)
-#include "stm32disco_conf.hh"
+#include "board_conf/stm32disco_conf.hh"
 
 #else
-#error                                                                                                                 \
-	"You must select your board: #define BOARD_CONF_DK2 to select the MP153 Discovery Board; #define BOARD_CONF_OSD32 to select the OSD32 Board; or #define BOARD_CONF_PATH \"path/to/board_conf.hh\" to set the path to a custom board conf file. Passing a compile flag -DBOARD_CONF_XXX is the preferred method, but you may also place the #define before any #include \"board_conf.hh\""
+#include "board_conf/stm32disco_conf.hh"
+#warning                                                                                                                 \
+	"No board was selected, defaulting to STM32 MP157 Discovery board. See src/board_conf.hh" 
 #endif

--- a/src/board_conf.hh
+++ b/src/board_conf.hh
@@ -1,7 +1,23 @@
-// Uncomment one of these to select your board:
-// Or add your own at the end
+#pragma once
 
-// #include "osd32brk_conf.hh"
-// namespace Board = OSD32BRK;
+// You must select your board:
+// -DBOARD_CONF_DK2 or #define BOARD_CONF_DK2 to select the MP153 Discovery Board;
+// -DBOARD_CONF_OSD32 or #define BOARD_CONF_OSD32 to select the OSD32 Board;
+// -DBOARD_CONF_PATH="path/file.hh" or #define BOARD_CONF_PATH "path/file.hh" to use a custom board conf file.
+// Passing a compile flag -DBOARD_CONF_XXX is the preferred method, but you may also place the #define before any #include "board_conf.hh"
 
+#ifdef BOARD_CONF_PATH
+#define HEADER_STRING_I(s) #s
+#define HEADER_STRING(s) HEADER_STRING_I(s)
+#include HEADER_STRING(BOARD_CONF_PATH)
+
+#elif defined(BOARD_CONF_OSD32)
+#include "osd32brk_conf.hh"
+
+#elif defined(BOARD_CONF_DK2)
 #include "stm32disco_conf.hh"
+
+#else
+#error                                                                                                                 \
+	"You must select your board: #define BOARD_CONF_DK2 to select the MP153 Discovery Board; #define BOARD_CONF_OSD32 to select the OSD32 Board; or #define BOARD_CONF_PATH \"path/to/board_conf.hh\" to set the path to a custom board conf file. Passing a compile flag -DBOARD_CONF_XXX is the preferred method, but you may also place the #define before any #include \"board_conf.hh\""
+#endif

--- a/src/board_conf/osd32brk_conf.hh
+++ b/src/board_conf/osd32brk_conf.hh
@@ -22,6 +22,11 @@ constexpr PinConf UartTX{GPIO::G, PinNum::_11, PinAF::AF_6};
 constexpr PinConf BootSelectPin{GPIO::B, PinNum::_6};
 constexpr bool UseBootSelect = false;
 
+// Freeze mode: halts booting after initializing everything
+// so you can load firmware via SWD/JTAG
+constexpr bool UseFreezePin = false;
+constexpr PinConf FreezePin{GPIO::Unused, PinNum::_0};
+
 namespace NORFlash
 {
 constexpr bool HasNORFlash = false;

--- a/src/board_conf/stm32disco_conf.hh
+++ b/src/board_conf/stm32disco_conf.hh
@@ -25,6 +25,11 @@ using GreenLED2 = BlueLED; // For compatibility with OSD32BRK board
 constexpr bool UseBootSelect = false;
 constexpr PinConf BootSelectPin{GPIO::A, PinNum::_13};
 
+// Freeze mode: halts booting after initializing everything
+// so you can load firmware via SWD/JTAG
+constexpr bool UseFreezePin = false;
+constexpr PinConf FreezePin{GPIO::Unused, PinNum::_0};
+
 constexpr uint32_t ConsoleUART = UART4_BASE;
 constexpr PinConf UartRX{GPIO::B, PinNum::_2, PinAF::AF_8};
 constexpr PinConf UartTX{GPIO::G, PinNum::_11, PinAF::AF_6};

--- a/src/boot_media_loader.hh
+++ b/src/boot_media_loader.hh
@@ -42,6 +42,7 @@ public:
 			return false;
 		}
 
+		log("Loading to 0x", Hex{_image_info.load_addr}, "\n");
 		bool ok = _loader->load_image(_image_info.load_addr, _image_info.size, target);
 		if (!ok) {
 			pr_err("Failed reading boot media when loading app img\n");
@@ -119,20 +120,20 @@ private:
 
 		uint32_t magic = be32_to_cpu(header.ih_magic);
 		if (magic == BootImageDef::IH_MAGIC) {
-			if (header.ih_load == 0) {
-				debug("ih_load is 0\n");
-				// On some system (e.g. powerpc), the load-address and
-				// entry-point is located at address 0. We can't load
-				// to 0-0x40. So skip header in this case.
-				_image_info.load_addr = be32_to_cpu(header.ih_load);
-				_image_info.entry_point = be32_to_cpu(header.ih_ep);
-				_image_info.size = be32_to_cpu(header.ih_size);
-			} else {
-				constexpr uint32_t header_size = sizeof(BootImageDef::image_header);
-				_image_info.entry_point = be32_to_cpu(header.ih_load);
-				_image_info.load_addr = _image_info.entry_point - header_size;
-				_image_info.size = be32_to_cpu(header.ih_size) + header_size;
-			}
+			// if (header.ih_load == 0) {
+			// 	debug("ih_load is 0\n");
+			// On some system (e.g. powerpc), the load-address and
+			// entry-point is located at address 0. We can't load
+			// to 0-0x40. So skip header in this case.
+			_image_info.load_addr = be32_to_cpu(header.ih_load);
+			_image_info.entry_point = be32_to_cpu(header.ih_ep);
+			_image_info.size = be32_to_cpu(header.ih_size);
+			// } else {
+			// 	constexpr uint32_t header_size = sizeof(BootImageDef::image_header);
+			// 	_image_info.entry_point = be32_to_cpu(header.ih_load);
+			// 	_image_info.load_addr = _image_info.entry_point - header_size;
+			// 	_image_info.size = be32_to_cpu(header.ih_size) + header_size;
+			// }
 
 			log("Image load addr: 0x", Hex{_image_info.load_addr});
 			log(" entry_addr: 0x", Hex{_image_info.entry_point});

--- a/src/drivers/ddr/stm32mp1_ram.cc
+++ b/src/drivers/ddr/stm32mp1_ram.cc
@@ -36,7 +36,8 @@ int stm32mp1_ddr_clk_enable(struct ddr_info *priv, u32 mem_speed)
 	log("DDR: mem_speed ", mem_speed, " kHz, RCC ", (u32)(ddrphy_clk / 1000), " kHz\n");
 
 	/* max 10% frequency delta */
-	ddr_clk = abs((int)ddrphy_clk - (int)mem_speed * 1000);
+	auto iabs = [](int x) { return x > 0 ? x : -x; };
+	ddr_clk = iabs((int)ddrphy_clk - (int)mem_speed * 1000);
 	if (ddr_clk > (mem_speed * 100)) {
 		pr_err("DDR expected freq %d kHz, current is %d kHz\n", mem_speed, (u32)(ddrphy_clk / 1000));
 		return -EINVAL;

--- a/src/drivers/pinconf.hh
+++ b/src/drivers/pinconf.hh
@@ -96,6 +96,8 @@ struct PinConf {
 	PinNum pin{PinNum::Unused};
 	PinAF af{PinAF::AFNone};
 
+	// FIXME: Polarity is not used
+
 	void init(PinMode mode,
 			  PinPull pull = PinPull::None,
 			  PinPolarity polarity = PinPolarity::Normal,

--- a/src/drivers/uart.hh
+++ b/src/drivers/uart.hh
@@ -108,10 +108,21 @@ private:
 
 	void _enable_rcc()
 	{
+		if constexpr (BASE_ADDR == USART1_BASE)
+			mdrivlib::RCC_Enable::USART1_::set();
+		if constexpr (BASE_ADDR == USART2_BASE)
+			mdrivlib::RCC_Enable::USART2_::set();
+		if constexpr (BASE_ADDR == USART3_BASE)
+			mdrivlib::RCC_Enable::USART3_::set();
 		if constexpr (BASE_ADDR == UART4_BASE)
-			RCC->MP_APB1ENSETR = RCC->MP_APB1ENSETR | RCC_MP_APB1ENSETR_UART4EN;
+			mdrivlib::RCC_Enable::UART4_::set();
+		if constexpr (BASE_ADDR == UART5_BASE)
+			mdrivlib::RCC_Enable::UART5_::set();
 		if constexpr (BASE_ADDR == USART6_BASE)
-			RCC->MP_APB2ENSETR = RCC->MP_APB2ENSETR | RCC_MP_APB2ENSETR_USART6EN;
-		// TODO: add the rest
+			mdrivlib::RCC_Enable::USART6_::set();
+		if constexpr (BASE_ADDR == UART7_BASE)
+			mdrivlib::RCC_Enable::UART7_::set();
+		if constexpr (BASE_ADDR == UART8_BASE)
+			mdrivlib::RCC_Enable::UART8_::set();
 	}
 };

--- a/src/main.cc
+++ b/src/main.cc
@@ -45,6 +45,18 @@ void main()
 
 	BootLoader::LoadTarget image_type = BootLoader::LoadTarget::App;
 
+	if constexpr (Board::UseFreezePin) {
+		Board::FreezePin.init(PinMode::Input, PinPull::Up);
+		// delay to allow pull-up to settle
+		udelay(1000);
+		if (!Board::FreezePin.read()) {
+			print("Freeze pin detected active, freezing.\n");
+			print("Ready to load firmware to DDR RAM via SWD/JTAG.\n");
+			while (true)
+				;
+		}
+	}
+
 	// Check Boot Select pin
 	if constexpr (Board::UseBootSelect) {
 		Board::BootSelectPin.init(PinMode::Input, PinPull::Up);

--- a/src/main.cc
+++ b/src/main.cc
@@ -47,10 +47,10 @@ void main()
 
 	// Check Boot Select pin
 	if constexpr (Board::UseBootSelect) {
-		Board::BootSelectPin.init(PinMode::Input, PinPull::Up, PinPolarity::Inverted);
+		Board::BootSelectPin.init(PinMode::Input, PinPull::Up);
 		// delay to allow pull-up to settle
 		udelay(1000);
-		if (Board::BootSelectPin.read()) {
+		if (!Board::BootSelectPin.read()) {
 			image_type = BootLoader::LoadTarget::SSBL;
 			print("Boot Select pin detected active: Loading alt image...\n");
 		}


### PR DESCRIPTION
This implements goals 1 and 2 of Issue #1 (allowing the pcb configuration to be selected at build time instead of by un/commenting out source code, and allowing board configurations files to be outside of the source tree).

The command is:
```
make BOARD_CONF=path/to/conf.hh
```

The path can be absolute or relative to the Makefile.

Or, instead of a path, one of the example config files can be used like this:

```
make BOARD_CONF=DK2

make BOARD_CONF=OSD32
```

This will use `src/board_conf/stm32disco_conf.hh` or `src/board_conf/osd32brk_conf.hh`, respectively.

By default, the DK2 board conf is used, but a warning is issued if not conf is specified.
